### PR TITLE
updated whois to send in Thread

### DIFF
--- a/Parsers/Admin tool - Whois.js
+++ b/Parsers/Admin tool - Whois.js
@@ -9,12 +9,13 @@ if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.
   rm.setHttpMethod('GET');
   rm.setLogLevel('all');
   rm.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  rm.setRequestHeader('authorization', 'Bearer '+gs.urlEncode(gs.getProperty('x_snc_slackerbot.SlackerBot.token')));
   var bodyString = '';
-  bodyString += 'token=' + gs.urlEncode(gs.getProperty('x_snc_slackerbot.SlackerBot.token'));
+//   bodyString += 'token=' + gs.urlEncode(gs.getProperty('x_snc_slackerbot.SlackerBot.token'));
   var user_id = current.text;
   user_id = user_id.replace('!whois <@', '');
   user_id = user_id.replace('>', '').trim();
-  bodyString += '&user=' + gs.urlEncode(user_id);
+  bodyString += 'user=' + gs.urlEncode(user_id);
   rm.setEndpoint('https://slack.com/api/users.info'+'?'+bodyString);
   var response = rm.execute();
   var response_body = JSON.parse(response.getBody());
@@ -31,7 +32,7 @@ if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.
   }
 
   if (response_body.user.name){
-    var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, '```' + message_body + '```');
+    var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, '```' + message_body + '```',true);
   } else {
     var send_chat2 = new x_snc_slackerbot.Slacker().send_chat(current, 'i dunno');
   }


### PR DESCRIPTION
#62 
1. Updated the REST header for authorization via token. It is necessary as i was getting error when not set. Error: {"ok":false,"error":"invalid_auth"}
2. Updated the bodyString as we are authenticating in REST header instead of passing token in bodyString.
3. Updated the send_chat to send in thread.

Please find API response in attached image:
API link to test - [Link](https://api.slack.com/methods/users.info/test)
You can see authorization as Bearer. That's why i need to update the REST header authorization to bearer and pass token in it.
<img width="469" alt="API response" src="https://user-images.githubusercontent.com/18590965/193496266-0d2453eb-aa5f-4850-a27e-6c99ae177548.png">

