### PR TITLE
 Fix-typo-in-the-Convert-Fahrenheit-to-Celcius-header

### DIFF
--- a/Parsers/Convert Fahrenheit to Celcius.js
+++ b/Parsers/Convert Fahrenheit to Celcius.js
@@ -1,5 +1,5 @@
 /*
-activation_example:30f or 30f degrees celcius
+activation_example:30f or 30 degrees Fahrenheit
 regex:(?:^|\s)(-?\d{1,3}\.?\d{0,2})°?\s?(?:degrees)?\s?f(?:ahrenheit)?\b
 flags:gmi
 */

--- a/Parsers/Convert Fahrenheit to Celsius.js
+++ b/Parsers/Convert Fahrenheit to Celsius.js
@@ -10,4 +10,4 @@ var numbertest = /-?\d{1,}\.?\d{0,}/;
 var numbermatch = numbertest.exec(match[0]);
 var ftoc = (parseFloat(numbermatch[0]) - 32) * 5/9;
 var originalnumber = parseFloat(numbermatch[0]).toFixed(2).toString().slice(-3) == '.00' ? parseFloat(numbermatch[0]).toFixed(2).toString().slice(0, -3) : parseFloat(numbermatch[0]).toFixed(2);
-var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, originalnumber + 'C is ' + ftoc.toFixed(2) + ' degrees in sane units (Celcius).');
+var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, originalnumber + 'C is ' + ftoc.toFixed(2) + ' degrees in sane units (Celsius).');


### PR DESCRIPTION
Corrected a typo in the header:
FROM: activation_example:30f or 30f degrees celcius
TO: activation_example:30f or 30 degrees Fahrenheit