### PR TITLE
Only fire +:trebek: once per message

### DIFF
--- a/Parsers/Remind someone to ask a question.js
+++ b/Parsers/Remind someone to ask a question.js
@@ -2,5 +2,16 @@
 emoji:trebek
 */
 
-new x_snc_slackerbot.Slacker().send_chat(current, 'http://www.quickmeme.com/img/b0/b0bf18d80b3fc08e45b6d3421377591d1077a3c983f75b10fa6c94934002eb09.jpg?' + new GlideDateTime().getNumericValue(), true)
+var quickMemeURL = 'http://www.quickmeme.com/img/b0/b0bf18d80b3fc08e45b6d3421377591d1077a3c983f75b10fa6c94934002eb09.jpg?';
+
+var previousMessage = new global.GlideQuery('x_snc_slackerbot_payload')
+    .where('payload', 'CONTAINS', '"type": "message"')
+    .where('payload', 'CONTAINS', '"is_bot": true')
+    .where('payload', 'CONTAINS', quickMemeURL)
+    .where('payload', 'CONTAINS', current.ts)
+    .selectOne()
+    .isPresent();
+
+if (!previousMessage)
+    new x_snc_slackerbot.Slacker().send_chat(current, quickMemeURL + new GlideDateTime().getNumericValue(), true);
 //a time signature is added to the URL so that Slack interprets each picture as a different picture (repeated pictures don't unfurl)


### PR DESCRIPTION
Closes #114.

I'm probably going to create another issue to try and make searching for bot messages less taxing. Bot replies don't show up in Chats so you have to parse the payload itself as a big string.

But, for now, this works.