### PR TITLE
Convert xkcd to block API and update doco

### DIFF
--- a/Parsers/Find a relevant XKCD comic.js
+++ b/Parsers/Find a relevant XKCD comic.js
@@ -4,6 +4,37 @@ regex:!xkcd
 flags:g
 */
 
+function buildComicOutput(xkcdPayload){
+    var blockArr = [];
+    var block = {};
+    block.type = "header";
+    block.text = {};
+    block.text.type = "plain_text";
+    block.text.text = xkcdPayload.safe_title + "";
+    blockArr.push(block);
+
+    block = {};
+    block.type = "image";
+    block.image_url = xkcdPayload.img + "";
+    block.alt_text = xkcdPayload.alt + "";
+    blockArr.push(block);
+
+    block = {};
+    block.type = "context";
+    block.elements = [];
+    var contextElement = {};
+    contextElement.type = "mrkdwn";
+    contextElement.text = "*Alt-text:* " + xkcdPayload.alt;
+    block.elements.push(contextElement);
+    blockArr.push(block);
+
+    block = {};
+    block.text = xkcdPayload.safe_title + "";
+    block.blocks = blockArr;
+
+    return block;
+}
+
 var search = gs.urlEncode(current.text.replace(/!xkcd/g, '').trim());
 
 var rm = new sn_ws.RESTMessageV2();
@@ -13,7 +44,7 @@ rm.setRequestHeader('User-Agent', 'servicenow');
 var response = rm.execute();
 var body = response.getBody();
 var result = body.match(/(?:<a href="\/wiki\/index.php\/)[0-9]+/gm)[0].replace(/<a href="\/wiki\/index.php\//g, '');
-var msg = '';
+var msg;
 if (parseInt(result)) {
     var rm2 = new sn_ws.RESTMessageV2();
     rm2.setHttpMethod('GET');
@@ -22,7 +53,7 @@ if (parseInt(result)) {
     var response2 = rm2.execute();
     var body2 = JSON.parse(response2.getBody());
 
-    msg = body2.safe_title + '\n' + body2.img + '\nAlt: ' + body2.alt;
+    msg = buildComicOutput(body2);
 } else {
     msg = 'No relevant XKCD found for `' + search + '`';
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This bot is what controls the @Slacker bot on the [sndevs.com](https://sndevs.co
 
 ## Contents
 
-- [Ways to contribut](#two-ways-to-contribute)
+- [Ways to contribute](#two-ways-to-contribute)
 - [Installing this bot on your slack server](#installing-this-bot-on-your-own-slack-server)
 - [GitHub to ServiceNow Integrations](#github-to-servicenow-integrations)
 - [Notes for setting this app up in Studio](#notes-for-setting-this-app-up-in-studio)
@@ -63,7 +63,7 @@ An accepted Pull Request and merge does not necessarily mean the functionality w
 * Copy and paste the manifest from either [appmanifest.json](Slack%20App%20Manifest/appmanifest.json) or [appmanifest.yaml](Slack%20App%20Manifest/appmanifest.yaml)
 * Create the app
 * Navigate to `Features` > `Event Subscriptions`
-* Populate the `Request URL` with: https://YOURDEVINSTANCE.service-now.com/api/x_snc_pointsthing/points_thing
+* Populate the `Request URL` with: https://YOURDEVINSTANCE.service-now.com/api/x_snc_slackerbot/slackerbot_event_handler
 > `When you tab out of the field, make sure the URL is "Verified" before you proceed.`
 * Navigate to `Settings` > `Install App`
 * Click the `Install to Workspace` button


### PR DESCRIPTION
### Justification for change:
Following the support of Block API, #159 was raised to convert this parser to support Blocks. This PR provides that functionality. It also performs a small tweak on the README, as there was a reference to another app.

I've tested this with a variety of passing and failing calls and the new functionality works - I did note a regression while testing, the failure case never hits due to the regex parsing the payload always hitting the 'latest comic' link on the explainxkcd page, meaning a failing call will always resolve to the latest comic link. I'll pop in an issue for this but it seems lower priority as it has existed regardless.

This resolves #159 

### Message formats for comparison:
#### Before
![image](https://user-images.githubusercontent.com/59789839/196633835-8842724e-b7e3-4b05-b77d-2ce9b1e54c50.png)

#### After
![image](https://user-images.githubusercontent.com/59789839/196634051-045adf56-645d-4052-9b0b-825070d756ec.png)
