### PR TITLE
Update Link to all ServiceNow Developer Meetups.js

### DIFF
--- a/Parsers/Link to all ServiceNow Developer Meetups.js
+++ b/Parsers/Link to all ServiceNow Developer Meetups.js
@@ -1,6 +1,6 @@
 /*
-activation_example:!meetups
-regex:^!meetups
+activation_example:!devmeetups
+regex:^!devmeetups
 flags:gmi
 */
 


### PR DESCRIPTION
Update to “Link to all ServiceNow Developer Meetups.js” to fix the conflict with !jitsi_meet application. As “meet” in !meetup triggers jitsi_meet. 

I’ve changed my activation/regex to !devmeetups instead. 