### PR TITLE
Update Tell a Random Joke.js

### DIFF
--- a/Parsers/Tell a Random Joke.js
+++ b/Parsers/Tell a Random Joke.js
@@ -2540,5 +2540,7 @@ var sendIt = new x_snc_slackerbot.Slacker().send_chat(current, jokes[random].jok
 
 if(jokes[random].punchline){
     //Send the punchline, as a thread reply if the TS existed, else, as a new message in the current channel
-    var sendItAgain = new x_snc_slackerbot.Slacker().send_chat(current, jokes[random].punchline, !sendIt.haveError());
+    var sendItResponse = JSON.parse(sendIt.getBody());
+    var main_ts = sendItResponse.message.ts;
+    var sendItAgain = new x_snc_slackerbot.Slacker().send_chat({"channel":current.channel,"thread_ts":main_ts}, jokes[random].punchline, true);
 }


### PR DESCRIPTION
fixes #199

The joke command was set to send the punchline to the original sending message, instead of the message of the joke line. the second send like has been updated to send according to the first one.

![image](https://github.com/ServiceNowDevProgram/SlackerBot/assets/31702109/ceff6e1b-7e4c-4102-8a7c-56465a3e0a5e)
