### PR TITLE
Update Start a Jitsi meeting.js

### DIFF
--- a/Parsers/Start a Jitsi meeting.js
+++ b/Parsers/Start a Jitsi meeting.js
@@ -1,7 +1,7 @@
 /*
 activation_example:!jitsi
-regex:^(!jitsi|!meet|!call)
-flags:gi
+regex:^(!jitsi|!meet(?!u)|!call)
+flags:gmi
 */
 
 var meeting_room, regex, response;


### PR DESCRIPTION
update the regex to ignore word if meet follow up by char 'u' e.g. meetups and fixed the flags issue #187 