### PR TITLE
Update Find a relevant XKCD comic.js to include link to comic

### DIFF
--- a/Parsers/Find a relevant XKCD comic.js
+++ b/Parsers/Find a relevant XKCD comic.js
@@ -24,7 +24,9 @@ function buildComicOutput(xkcdPayload) {
     block.elements = [];
     var contextElement = {};
     contextElement.type = "mrkdwn";
-    contextElement.text = "*Alt-text:* " + xkcdPayload.alt;
+    contextElement.text = "*Alt-text:* " + xkcdPayload.alt + "\n"; 
+	contextElement.text += "*Link:* https://xkcd.com/" + xkcdPayload.num + "/";
+	
     block.elements.push(contextElement);
     blockArr.push(block);
 


### PR DESCRIPTION
Fixes #195 

![image](https://github.com/ServiceNowDevProgram/SlackerBot/assets/57676066/3218634d-9782-4ee2-9344-93d53837217c)

The xkcd command should look like this now

Note that the payload response from xkcd api link returns an empty string e.g.

```
{
   "month":"7",
   "num":614,
   "link":"",
   "year":"2009",
   "news":"",
   "safe_title":"Woodpecker",
   "transcript":"[[A man with a beret and a woman are standing on a boardwalk, leaning on a handrail.]]\nMan: A woodpecker!\n<<Pop pop pop>>\nWoman: Yup.\n\n[[The woodpecker is banging its head against a tree.]]\nWoman: He hatched about this time last year.\n<<Pop pop pop pop>>\n\n[[The woman walks away.  The man is still standing at the handrail.]]\n\nMan: ... woodpecker?\nMan: It's your birthday!\n\nMan: Did you know?\n\nMan: Did... did nobody tell you?\n\n[[The man stands, looking.]]\n\n[[The man walks away.]]\n\n[[There is a tree.]]\n\n[[The man approaches the tree with a present in a box, tied up with ribbon.]]\n\n[[The man sets the present down at the base of the tree and looks up.]]\n\n[[The man walks away.]]\n\n[[The present is sitting at the bottom of the tree.]]\n\n[[The woodpecker looks down at the present.]]\n\n[[The woodpecker sits on the present.]]\n\n[[The woodpecker pulls on the ribbon tying the present closed.]]\n\n((full width panel))\n[[The woodpecker is flying, with an electric drill dangling from its feet, held by the cord.]]\n\n{{Title text: If you don't have an extension cord I can get that too.  Because we're friends!  Right?}}",
   "alt":"If you don't have an extension cord I can get that too.  Because we're friends!  Right?",
   "img":"https://imgs.xkcd.com/comics/woodpecker.png",
   "title":"Woodpecker",
   "day":"24"
}
```

so we need to use the num instead and manually create the link