### PR TITLE
Update Start a Jitsi meeting.js

### DIFF
--- a/Parsers/Start a Jitsi meeting.js
+++ b/Parsers/Start a Jitsi meeting.js
@@ -1,7 +1,7 @@
 /*
 activation_example:!jitsi
-regex:^(!jitsi|!meet|!call)
-flags:gi
+regex:^(!jitsi|!meet\b|!call)
+flags:gmi
 */
 
 var meeting_room, regex, response;


### PR DESCRIPTION
adding word boundary \b for !meet that will cover all the scenarios for !meetup !meeting to not trigger this parser and fix the flags to gmi

Fixes #187