### PR TITLE
Update the vancouver parse to have word boundaries on the regex

### DIFF
--- a/Parsers/Reaction to vancouver.js
+++ b/Parsers/Reaction to vancouver.js
@@ -1,6 +1,6 @@
 /*
 activation_example:vancouver
-regex:vancouver
+regex:\bvancouver\b
 flags:gmi
 order:200
 stop_processing:false


### PR DESCRIPTION
Fixes #231

Example of how vancouver reactions work with these changes
![image](https://github.com/ServiceNowDevProgram/SlackerBot/assets/57676066/4369bde4-f310-4b8f-aa60-c4c58f5a8a78)
