### PR TITLE
Update Release reaction RegEx and make names consistent

### DIFF
--- a/Parsers/Release Vancouver.js
+++ b/Parsers/Release Vancouver.js
@@ -1,6 +1,6 @@
 /*
 activation_example:vancouver
-regex:\bvancouver\b
+regex:(?i)(?<![:\/\w])vancouver(?![\/\w])
 flags:gmi
 order:200
 stop_processing:false

--- a/Parsers/Utah triggers Utah react.js
+++ b/Parsers/Utah triggers Utah react.js
@@ -1,6 +1,6 @@
 /*
 activation_example: Please check the utah channel
-regex:\butah\b
+regex:(?i)(?<![:\/\w])utah(?![\/\w])
 flags:gmi
 order:200
 stop_processing:false


### PR DESCRIPTION
Updated RegEx to be more restrictive and not match on the release name in a URL (for example) and renamed family release parsers to be more consistent