### PR TITLE
Fix regex issue on new parsers causing strange behaviour

### DIFF
--- a/Parsers/Convert Kilometre to Miles.js
+++ b/Parsers/Convert Kilometre to Miles.js
@@ -1,10 +1,10 @@
 /*
 activation_example:1km or 1 kilometre
-regex:(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b/gmi
+regex:(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b
 flags:gmi
 */
 
-var regextest = (?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b/gmi;
+var regextest = /(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b/gmi;
 var match = regextest.exec(current.text);
 var numbertest = /-?\d{1,}\.?\d{0,}/;
 var numbermatch = numbertest.exec(match[0]);

--- a/Parsers/Convert Miles to Kilometre.js
+++ b/Parsers/Convert Miles to Kilometre.js
@@ -1,10 +1,10 @@
 /*
 activation_example:1 mile or 2 miles
-regex:(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b/gmi
+regex:(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?k(m?|ilometer|ilometers|ilometre|ilometres)\b
 flags:gmi
 */
 
-var regextest = (?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?m(ile|iles)\b/gmi;
+var regextest = /(?:^|\s)(=?-?\d{1,5}\.?\d{0,8})\s?m(ile|iles)\b/gmi;
 var match = regextest.exec(current.text);
 var numbertest = /-?\d{1,}\.?\d{0,}/;
 var numbermatch = numbertest.exec(match[0]);

--- a/Parsers/Show all SlackerBot commands.js
+++ b/Parsers/Show all SlackerBot commands.js
@@ -2,9 +2,9 @@
 activation_example:!help
 regex:!help
 flags:gmi
+order:1
+stop_processing:true
 */
-
-
 
 var parser = new GlideRecord('x_snc_slackerbot_parser');
 parser.addQuery('active', 'true');


### PR DESCRIPTION
### Why

When reviewing these two conversion parsers, I missed the flags in the regex string and the bad regex declaration. This PR addresses these, and additionally moves help to the top of the order to avoid it stopping working when bad regex is evaluated