### PR TITLE
Finalise user information and verification functionality and perform fixes

### DIFF
--- a/Parsers/Admin tool - Admin information.js
+++ b/Parsers/Admin tool - Admin information.js
@@ -1,6 +1,6 @@
 /*
-activation_example:!verify-admin @Astrid. Optional second arg to set message
-regex:^!verify-admin\b
+activation_example:!info-admin @Astrid Notes here
+regex:^!info-admin\b
 flags:gmi
 */
 
@@ -10,20 +10,18 @@ if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.
 
   // Grab user ID and then prep invocation if User-visible info provided
   var invocation = current.text;
-  var user_id = invocation.replace('!verify-admin <@', '');
+  var user_id = invocation.replace('!info-admin <@', '');
   user_id = user_id.replace('>', '').trim();
-  invocation = invocation.replace('!verify-admin <@' + user_id + '>','').trim();
+  invocation = invocation.replace('!info-admin <@' + user_id + '>','').trim();
   
   var grUser = new GlideRecord('x_snc_slackerbot_user');
   if(grUser.get('user_id',user_id) && Object.keys(grUser).indexOf('verified') != -1){
     if(invocation.length == 0){
-      verification_status = !(grUser.getValue('verified') == 1 ? true : false); // Get verified and toggle
-      grUser.setValue('verified',verification_status);
-      message_body += 'Updated <@' + user_id + '>\'s verification status. They are now ' + (verification_status ? 'verified.' : 'unverified.');
+      message_body += 'A message is required to update/replace the existing admin info. Call in format !info-admin @User Admin Note Here';
     } else {
-      grUser.setValue('user_info', invocation);
+      grUser.setValue('admin_info', invocation);
       grUser.update();
-      message_body += 'Updated <@' + user_id + '>\'s user info message.';
+      message_body += 'Updated <@' + user_id + '>\'s admin info message.';
     }
     grUser.update();
   }

--- a/Parsers/Admin tool - Verify.js
+++ b/Parsers/Admin tool - Verify.js
@@ -23,7 +23,7 @@ if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.
     } else {
       grUser.setValue('user_info', invocation);
       grUser.update();
-      message_body += 'Updated <@' + user_id + '>\'s user info message.');
+      message_body += 'Updated <@' + user_id + '>\'s user info message.';
     }
     grUser.update();
   }

--- a/Parsers/Admin tool - Whois.js
+++ b/Parsers/Admin tool - Whois.js
@@ -26,7 +26,12 @@ if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.
       message_body += 'profile: \n';
       for (var prof_key in response_body.user.profile) {
         if (prof_key.indexOf('image_') != -1) continue;
-        message_body += '  ' + prof_key + ': ' + response_body.user.profile[prof_key] + '\n';
+        if (prof_key == 'status_emoji_display_info'){
+          message_body += '  status_emoji_display_info: \n';
+          for (var stat_key in response_body.user.profile.status_emoji_display_info){
+            message_body += '    ' + stat_key + ': ' + response_body.user.profile.status_emoji_display_info[stat_key] + '\n';
+          }
+        } else message_body += '  ' + prof_key + ': ' + response_body.user.profile[prof_key] + '\n';
       }
     } else message_body += key + ': ' + response_body.user[key] + '\n';
   }

--- a/Parsers/Check if user is verified.js
+++ b/Parsers/Check if user is verified.js
@@ -1,0 +1,25 @@
+/*
+activation_example:!verify @Astrid - Admin-validated user identity info
+regex:^!verify\b
+flags:gmi
+*/
+
+var message_body = '';
+var verification_status = '';
+var user_info = '';
+var user_id = current.text.replace('!verify <@', '');
+user_id = user_id.replace('>', '').trim();
+
+var grUser = new GlideRecord('x_snc_slackerbot_user');
+if(grUser.get('user_id',user_id) && Object.keys(grUser).indexOf('verified') != -1){
+    verification_status = (grUser.getValue('verified') == 1 ? true : false) ? 'has been verified' : 'has not been verified';
+    user_info = grUser.getValue('user_info').toString();
+
+    message_body += '' + grUser.getValue('name') + '\'s identity '+ verification_status + '.';
+    if(!gs.nil(user_info)) message_body += '\nThe following information has been noted about this user: ' + user_info;
+}
+else {
+  message_body += 'I\'m afraid I can\'t do that. Either the user does not exist, or the logic to support this functionality is not yet on the instance.';
+}
+
+var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, message_body, true);

--- a/Parsers/Write text in SponGeBoB case.js
+++ b/Parsers/Write text in SponGeBoB case.js
@@ -4,7 +4,7 @@ regex:!spongebob
 flags:gmi
 */
 
-var text = current.text.replace(/!spongebob/gmi, "").trim();
+var text = current.text.replace(/!spongebob/gmi, '').trim();
 var newText = text.split('').map(function(e) {
     return Math.floor(Math.random() * 2) ? e.toUpperCase() : e.toLowerCase();
 }).join('').replaceAll('I','i').replaceAll('l','L');


### PR DESCRIPTION
## Summary

This PR follows on from #294 which brought the start of this functionality. This PR fixes a typo in admin variant of Verify and changes its invocation. It adds the user-facing variant, and also adds the admin info capability. Lastly, this also includes a small tweak to the spongebob parser to allow this to be created in the instance, and an extension to the Whois parser. This resolves #210.

## Details

Added two parsers:
- `Parsers/Admin tool - Admin information.js`. This sets the admin-visible message.
- `Parsers/Check if user is verified.js`. This allows any user to query verification information

Updated three parsers:
- `Parsers/Admin tool - Verify.js`. Changes the call and fixes a typo I missed
- `Parsers/Admin tool - Whois.js`. Extends to parse an object from the user profile component
- `Parsers/Write text in SponGeBoB case.js`. Trivial tweak to get the SRAPI to create this parser.\*

\* Moving this to the parser directory caused the SRAPI for Parsers to give a 500, as the format of a directory change does not match update payloads. This will counts as an update payload for this purpose

## Note

There is functionality in this PR to bridge the space between parser approval and schema update for SNDevs. This can be removed in a later PR