### PR TITLE
Fixes github automation set-output deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         echo "$GITHUB_CONTEXT"
     - name: Contact DPR
       id: myRequest
-      uses: fjogeleit/http-request-action@v1.8.1
+      uses: fjogeleit/http-request-action@v1
       with:
         url: ${{ format('https://{0}.service-now.com/api/x_snc_slackerbot/slackerbotgithub', secrets.SN_INSTANCE_NAME) }}
 #         url: 'https://devprogramresources.service-now.com/api/x_snc_slackerbot/slackerbotgithub'


### PR DESCRIPTION
"Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files." was happening on every action deployment. this updates the http-request-action action, tested and verified on separate repo.