### PR TITLE
Incorrect API url in "another fact" parser

### DIFF
--- a/Parsers/Another fact.js
+++ b/Parsers/Another fact.js
@@ -6,7 +6,7 @@ flags:gi
 
 if (Math.floor(Math.random() * 4) == 0) {
     var fact = new sn_ws.RESTMessageV2();
-    fact.setEndpoint('https://uselessfacts.jsph.pl/api/v2/facts/random/');
+    fact.setEndpoint('https://uselessfacts.jsph.pl/api/v2/facts/random');
     fact.setHttpMethod("GET");
     var chatResponse = fact.execute();
     var chatResponseBody = JSON.parse(chatResponse.getBody());


### PR DESCRIPTION
https://uselessfacts.jsph.pl/api/v2/facts/random/ returns a 404

https://uselessfacts.jsph.pl/api/v2/facts/random is correct