### PR TITLE
News Article Parser

### DIFF
--- a/Parsers/News Article Parser.js
+++ b/Parsers/News Article Parser.js
@@ -8,7 +8,7 @@ var where = current.text.indexOf('!parse_news ') + 12;
 var term = current.text.substr(where).trim();
 
 // Build the search URL using a public news API
-var searchUrl = 'https://newsapi.org/v2/everything?q=' + term + '&apiKey=981bfffa7e064a22aa8d7c8723e673ae';
+var searchUrl = 'https://newsapi.org/v2/everything?q=' + term + '&apiKey='+gs.getProperty("newsapi.key");
 
 // Replace "YOUR_API_KEY" with your actual News API key
 var chatReq = new sn_ws.RESTMessageV2();

--- a/Parsers/News Article Parser.js
+++ b/Parsers/News Article Parser.js
@@ -1,0 +1,37 @@
+/*
+activation_example:!parse_news name of news website
+regex:!parse_news
+flags:gmi
+*/
+
+var where = current.text.indexOf('!parse_news ') + 12;
+var term = current.text.substr(where).trim();
+
+// Build the search URL using a public news API
+var searchUrl = 'https://newsapi.org/v2/everything?q=' + term + '&apiKey=981bfffa7e064a22aa8d7c8723e673ae';
+
+// Replace "YOUR_API_KEY" with your actual News API key
+var chatReq = new sn_ws.RESTMessageV2();
+chatReq.setEndpoint(searchUrl);
+chatReq.setHttpMethod("GET");
+var chatResponse = chatReq.execute();
+var chatResponseBody = chatResponse.getBody();
+
+// Parse the API response as JSON
+var responseData = JSON.parse(chatResponseBody);
+
+// Check if the API response contains any articles
+if (responseData.articles.length > 0) {
+  // Extract information from the first article
+  var article = responseData.articles[0];
+  var title = article.title;
+  var author = article.author;
+  var description = article.description;
+  var url = article.url;
+
+  // Send the extracted information as a Slack message
+  var message = "**Title:** " + title + "\n**Author:** " + author + "\n**Description:** " + description + "\n**URL:** " + url;
+  new x_snc_slackerbot.Slacker().send_chat(current, message, false);
+} else {
+  new x_snc_slackerbot.Slacker().send_chat(current, "Sorry, I couldn't find any news articles related to \"" + term + "\".", false);
+}

--- a/Parsers/News Article Parser.js
+++ b/Parsers/News Article Parser.js
@@ -1,16 +1,14 @@
 /*
-activation_example:!parse_news name of news website
-regex:!parse_news
+activation_example:!news topic or story to search for
+regex:!news
 flags:gmi
 */
 
-var where = current.text.indexOf('!parse_news ') + 12;
-var term = current.text.substr(where).trim();
+var term = current.text.replace("!news ", "").trim();
 
-// Build the search URL using a public news API
-var searchUrl = 'https://newsapi.org/v2/everything?q=' + term + '&apiKey='+gs.getProperty("newsapi.key");
+// Build the search URL using a public news API to search for a specific topic or story
+var searchUrl = 'https://newsapi.org/v2/everything?q=' + encodeURIComponent(term) + '&apiKey=' + gs.getProperty("newsapi.key");
 
-// Replace "YOUR_API_KEY" with your actual News API key
 var chatReq = new sn_ws.RESTMessageV2();
 chatReq.setEndpoint(searchUrl);
 chatReq.setHttpMethod("GET");
@@ -25,13 +23,13 @@ if (responseData.articles.length > 0) {
   // Extract information from the first article
   var article = responseData.articles[0];
   var title = article.title;
-  var author = article.author;
-  var description = article.description;
+  var author = article.author || "Unknown author";
+  var description = article.description.length > 255 ? article.description.substring(0, 252) + "... Read More" : article.description;
   var url = article.url;
 
   // Send the extracted information as a Slack message
-  var message = "**Title:** " + title + "\n**Author:** " + author + "\n**Description:** " + description + "\n**URL:** " + url;
-  new x_snc_slackerbot.Slacker().send_chat(current, message, false);
+  var message = "*Title:* " + title + "\n*Author:* " + author + "\n*Description:* " + description + "\n*URL:* " + url;
+  new x_snc_slackerbot.Slacker().send_chat(current, message, true);
 } else {
-  new x_snc_slackerbot.Slacker().send_chat(current, "Sorry, I couldn't find any news articles related to \"" + term + "\".", false);
+  new x_snc_slackerbot.Slacker().send_chat(current, "Sorry, I couldn't find any news articles related to \"" + term + "\".", true);
 }


### PR DESCRIPTION
Parses news articles using the News API. The bot extracts title, author, description, and URL from articles based on user-provided keywords. Added error handling for cases where no articles are found.