### PR TITLE
Update Convert Fahrenheit to Celsius.js

### DIFF
--- a/Parsers/Convert Fahrenheit to Celsius.js
+++ b/Parsers/Convert Fahrenheit to Celsius.js
@@ -5,9 +5,20 @@ flags:gmi
 */
 
 var regextest = /(?:^|\s)(-?\d{1,3}\.?\d{0,2})°?\s?(?:degrees)?\s?f(?:ahrenheit)?\b/gmi;
-var match = regextest.exec(current.text);
 var numbertest = /-?\d{1,}\.?\d{0,}/;
-var numbermatch = numbertest.exec(match[0]);
-var ftoc = (parseFloat(numbermatch[0]) - 32) * 5/9;
-var originalnumber = parseFloat(numbermatch[0]).toFixed(2).toString().slice(-3) == '.00' ? parseFloat(numbermatch[0]).toFixed(2).toString().slice(0, -3) : parseFloat(numbermatch[0]).toFixed(2);
-var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, originalnumber + '°F is ' + ftoc.toFixed(2) + ' degrees in sane units (Celsius).');
+var conversions = [];
+
+var match;
+while ((match = regextest.exec(current.text)) !== null) {
+    var numbermatch = numbertest.exec(match[0]);
+    var fahrenheit = parseFloat(numbermatch[0]);
+    var celsius = (fahrenheit - 32) * 5/9;
+    
+    var originalNumber = fahrenheit.toFixed(2).toString().slice(-3) == '.00' ? 
+        fahrenheit.toFixed(0) : fahrenheit.toFixed(2);
+    
+    conversions.push(originalNumber + '°F is ' + celsius.toFixed(2) + ' degrees in sane units (Celsius).');
+    current.text = current.text.replace(match[0], celsius.toFixed(2) + '°C');
+}
+var conversionMessage = conversions.join('\n');
+var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, conversionMessage);


### PR DESCRIPTION
Modified parser to convert all Fahrenheit temperatures in the input string to Celsius instead of only the first temp in the string.

E.x. 

"it went from 45F to 25F overnight and then back to 55F the next day"

Produces
45°F is 7.22 degrees in sane units (Celsius).
25°F is -3.89 degrees in sane units (Celsius).
55°F is 12.78 degrees in sane units (Celsius).