### PR TITLE
Improve !verify-admin and patch !issue

### DIFF
--- a/Parsers/Admin tool - Verify.js
+++ b/Parsers/Admin tool - Verify.js
@@ -1,35 +1,77 @@
 /*
-activation_example:!verify-admin @Astrid
-regex:^!verify-admin\b
+activation_example:!verify-admin @Astrid, !verify-admin -help
+regex:^!verify-admin\u0020?
 flags:gi
 */
 
-if (current.channel == "GD51HTR46" || current.channel == "G9LAJG7G8" || current.channel == "G7M4AP6U8") { //admin channels on sndevs
-  var message_body = '';
-  var verification_status = false;
-
-  // Grab user ID and then prep invocation if User-visible info provided
-  var invocation = current.text;
-  var user_id = invocation.replace('!verify-admin <@', '');
-  user_id = user_id.replace(/>.*/, '').trim();
-  invocation = invocation.replace('!verify-admin <@' + user_id + '>','').trim();
+if (current.channel == 'GD51HTR46' || current.channel == 'G9LAJG7G8' || current.channel == 'G7M4AP6U8') { //admin channels on sndevs
+    var messageBody = '';
+    var userId = '';
+    var description = '';
+    var verificationStatus = null;
+    var slacker = new x_snc_slackerbot.Slacker();
   
-  var grUser = new GlideRecord('x_snc_slackerbot_user');
-  if(grUser.get('user_id',user_id) && Object.keys(grUser).indexOf('verified') != -1){
-    if(invocation.length == 0){
-      verification_status = !(grUser.getValue('verified') == 1 ? true : false); // Get verified and toggle
-      grUser.setValue('verified',verification_status);
-      message_body += 'Updated <@' + user_id + '>\'s verification status. They are now ' + (verification_status ? 'verified.' : 'unverified. To add a user-visible note instead of toggling verification, add text after `!verify-admin @User `. Example: `!verify-admin @Astrid Is upside down`');
-    } else {
-      grUser.setValue('user_info', invocation);
-      grUser.update();
-      message_body += 'Updated <@' + user_id + '>\'s user info message.';
-    }
-    grUser.update();
-  }
-  else {
-    message_body += 'I\'m afraid I can\'t do that. Either the user does not exist, or the logic to support this functionality is not yet on the instance.';
-  }
+    // Grab user ID and then prep invocation if User-visible info provided
+    var invocation = current.text.replace(/^!verify-admin\u0020?/gi,'').trim();
+    var paramArr = invocation.split(' ');
 
-  var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, message_body, true);
-}
+    if(paramArr.length == 0){
+        messageBody = '!verify-admin must be called with a user tag, followed by an optional parameter and optional description. For example: `!verify-admin @Astrid -unv Is an Impasta`\n\nThe full list of accepted triggers can be found by sending `!verify-admin -help`';
+    }
+
+    if(paramArr.length == 1){
+        if(paramArr[0] == '-help'){
+            messageBody = 'Admin Tool - Verify user\nA parser for setting user verification and descriptions. *Note:* This parser can only be triggered from admin channels specified.\n\nUsage: `!verify-admin @username [-v|-unv] [message]`\nExamples:\n`!verify-admin @Astrid -unv Is an Impasta`\n`!verify-admin @Astrid Some Role, Some Company`\n`!verify-admin @Astrid -v`\n\nSupported flags:\n-v: Verify the user\n-unv: Remove verification from user\n-help: Show this message';
+        } else {
+            messageBody = '!verify-admin must be called with a user tag, followed by an optional parameter and optional description. For example: `!verify-admin @Astrid -unv Is an Impasta`\n\nThe full list of accepted triggers can be found by sending `!verify-admin -help`';
+        }
+    }
+
+    if(paramArr.length >= 2){
+        if(/^<@.*?>$/.test(paramArr[0])){
+            userId = paramArr[0].replace(/[<>@]/g,'');
+            paramArr.shift();
+        } else {
+            messageBody = '!verify-admin must be called with a user tag, followed by an optional parameter and optional description. For example: `!verify-admin @Astrid -unv Is an Impasta`\n\nThe full list of accepted triggers can be found by sending `!verify-admin -help`';
+        }
+    }
+    
+    if(messageBody.length > 0 || userId.length == 0){
+        if(messageBody.length == 0 && userId.length == 0){
+            messageBody = 'The provided user details are malformed, meaning the user cannot be verified.';
+        }
+        slacker.send_chat(current, messageBody, true);
+    } else {
+        if(paramArr.indexOf('-v') > -1 && paramArr.indexOf('-unv') > -1){
+            messageBody = 'Please only provide one verify parameter in your message. Verification message ignored.';
+            slacker.send_chat(current, messageBody, true);
+        } else {
+            if(paramArr.indexOf('-v') > -1){
+                verificationStatus = true;
+            }
+
+            if(paramArr.indexOf('-unv') > -1){
+                verificationStatus = false;
+            }
+
+            if(verificationStatus != null){
+                paramArr = paramArr.filter(function(val){
+                    return (val != '-v' && val != '-unv');
+                })
+            }
+
+            description = paramArr.join(' ');
+            var grUser = new GlideRecord('x_snc_slackerbot_user');
+            if(grUser.get('user_id',userId)){
+                verificationStatus != null ? grUser.setValue('verified',verificationStatus) : null;
+                description.length > 0 ? grUser.setValue('user_info',description) : null;
+                grUser.update();
+
+                messageBody = 'Updated <@' + userId + '>\'s verification information. Run `!verify` or `!whois` to verify output.';
+            } else {
+                messageBody += 'I\'m afraid I can\'t do that as the user does not exist.';
+            }
+            slacker.send_chat(current, messageBody, true);
+        }
+    }
+  }

--- a/Parsers/Create a GitHub issue.js
+++ b/Parsers/Create a GitHub issue.js
@@ -72,7 +72,7 @@ if(message.length > 0 || selectedRepository.length == 0 || clientId == 'invalid_
             slacker.send_chat(current, message, false);
         }  else {
             blockMsg = buildBlockMessage(output.number, output.html_url);
-            slacker.send_chat(current, message, false);
+            slacker.send_chat(current, blockMsg, false);
         }
     }
 }


### PR DESCRIPTION
## Description
#328 called for improving the functionality of `!verify-admin`. In the current state, an admin must use this parser twice to verify a user and then set their message. This PR reworks the logic used to allow this to be done in a single call.

Resolves #328 

This also includes a small fix to the `!issue` parser to ensure rich feedback is returned on issue creation.

### Note on change
This change removes the prior functionality that allowed the user to toggle verification by calling `!verify-admin username`. It contains a message about calling the new help method, and additionally I will ask the admins to share this knowledge internally to minimize the impact of the 'breaking' change.

## Usage

```
!verify-admin username [-v|-unv] [message]
```

### Examples:
#### Verify and update message

```
!verify-admin @SapphicFire -v Hacktoberfest Contributor
```

#### Remove user verification
```
!verify-admin @SapphicFire -unv
```

#### Update message
```
!verify-admin @SapphicFire Hacktoberfest Moderator
```