### PR TITLE
Create Highlight Maintatiners.js

### DIFF
--- a/Parsers/Highlight Maintatiners.js
+++ b/Parsers/Highlight Maintatiners.js
@@ -1,0 +1,12 @@
+/*
+activation_example:!maintainers
+regex:!hackmaintainers|!hacktobermaintainers|!maintainershacktoberfest
+flags:gmi
+*/
+
+(function(){
+  
+  var strMessage = 'Navigate to `https://github.com/ServiceNowDevProgram/Hacktoberfest?tab=readme-ov-file#reviewers` to checkout the Hacktoberfest crew who are maintaining the hacktoberfest projects '
+  var send_chat = new x_snc_slackerbot.Slacker().send_chat(current, strMessage, false);
+  
+})();


### PR DESCRIPTION
Highlight maintainers is a tribute to the maintainers for their valuable time. !maintainers will give a link to the Hacktoberfest page to where the maintainers section is present so that everyone can take a look at the maintainers who have been spending their valuable time to review the pull requests.